### PR TITLE
issue 3; vi mode not upding history

### DIFF
--- a/pyreadline/test/test_vi.py
+++ b/pyreadline/test/test_vi.py
@@ -135,6 +135,18 @@ class Tests (unittest.TestCase):
         r.input ('"^"')
         self.assertEqual (0, r.line_cursor)
 
+    def test_history_add (self):
+        r = ViModeTest ()
+        r.input ('"abc"')
+        r.input ('Return')
+        r.input ('"def"')
+        r.input ('Return')
+        r.input ('Escape')
+        r.input ('"k"')
+        self.assertEqual ('def', r.line)
+        r.input ('"k"')
+        self.assertEqual ('abc', r.line)
+
     def test_history_alpha (self):
         r = ViModeTest ()
         r.add_history ('abc')


### PR DESCRIPTION
A gentleman on stackoverflow was having a problem with vi mode.

http://stackoverflow.com/questions/1837693/using-the-python-shell-in-vi-mode-on-windows/9759079#9759079

I added an issue: https://github.com/pyreadline/pyreadline/issues/3

This change adds the following:
- a new unit test
- fix to `vi_accept_line` to append line to history
- fix to `vi_search_*` functions to compliment history change.

Have fun,
-Will
