### PR TITLE
Isolate kernel32 DLL usage.

### DIFF
--- a/pyreadline/console/console.py
+++ b/pyreadline/console/console.py
@@ -132,81 +132,40 @@ class CONSOLE_CURSOR_INFO(Structure):
                 ("bVisible", BOOL)]
 PCONSOLE_CURSOR_INFO = c_void_p
 
-_L = locals()
-for func in '''
-        CreateConsoleScreenBuffer
-        FillConsoleOutputAttribute
-        FillConsoleOutputCharacterW
-        GetConsoleCursorInfo
-        GetConsoleMode
-        GetConsoleScreenBufferInfo
-        GetConsoleTitleW
-        GetProcAddress
-        GetStdHandle
-        PeekConsoleInputW
-        ReadConsoleInputW
-        ScrollConsoleScreenBufferW
-        SetConsoleActiveScreenBuffer
-        SetConsoleCursorInfo
-        SetConsoleCursorPosition
-        SetConsoleMode
-        SetConsoleScreenBufferSize
-        SetConsoleTextAttribute
-        SetConsoleTitleW
-        SetConsoleWindowInfo
-        WriteConsoleW
-        WriteConsoleOutputCharacterW
-        WriteFile
+L = locals()
+k32 = windll.kernel32
+for line in '''
+        CreateConsoleScreenBuffer,HANDLE,DWORD,DWORD,c_void_p,DWORD,LPVOID
+        FillConsoleOutputAttribute,BOOL,HANDLE,WORD,DWORD,COORD,LPDWORD
+        FillConsoleOutputCharacterW,BOOL,HANDLE,c_wchar,DWORD,COORD,LPDWORD
+        GetConsoleCursorInfo,BOOL,HANDLE,PCONSOLE_CURSOR_INFO
+        GetConsoleMode,BOOL,HANDLE,LPDWORD
+        GetConsoleScreenBufferInfo,BOOL,HANDLE,PCONSOLE_SCREEN_BUFFER_INFO
+        GetConsoleTitleW,DWORD,LPWSTR,DWORD
+        GetProcAddress,FARPROC,HMODULE,LPCSTR
+        GetStdHandle,HANDLE,DWORD
+        PeekConsoleInputW,BOOL,HANDLE,PINPUT_RECORD,DWORD,LPDWORD
+        ReadConsoleInputW,BOOL,HANDLE,PINPUT_RECORD,DWORD,LPDWORD
+        ScrollConsoleScreenBufferW,BOOL,HANDLE,PSMALL_RECT,PSMALL_RECT,COORD,PCHAR_INFO
+        SetConsoleActiveScreenBuffer,BOOL,HANDLE
+        SetConsoleCursorInfo,BOOL,HANDLE,PCONSOLE_CURSOR_INFO
+        SetConsoleCursorPosition,BOOL,HANDLE,COORD
+        SetConsoleMode,BOOL,HANDLE,DWORD
+        SetConsoleScreenBufferSize,BOOL,HANDLE,COORD
+        SetConsoleTextAttribute,BOOL,HANDLE,WORD
+        SetConsoleTitleW,BOOL,LPCWSTR
+        SetConsoleWindowInfo,BOOL,HANDLE,BOOL,PSMALL_RECT
+        WriteConsoleW,BOOL,HANDLE,c_void_p,DWORD,LPDWORD,LPVOID
+        WriteConsoleOutputCharacterW,BOOL,HANDLE,LPCWSTR,DWORD,COORD,LPDWORD
+        WriteFile,BOOL,HANDLE,LPCVOID,DWORD,LPDWORD,c_void_p
         '''.split():
-    _L[func] = getattr(windll.kernel32, func)
-del _L, func
-
-CreateConsoleScreenBuffer.restype = HANDLE
-CreateConsoleScreenBuffer.argtypes = [DWORD, DWORD, c_void_p, DWORD, LPVOID]
-FillConsoleOutputAttribute.restype = BOOL
-FillConsoleOutputAttribute.argtypes = [HANDLE, WORD, DWORD, COORD, LPDWORD]
-FillConsoleOutputCharacterW.restype = BOOL
-FillConsoleOutputCharacterW.argtypes = [HANDLE, c_wchar, DWORD, COORD, LPDWORD]
-GetConsoleCursorInfo.restype = BOOL
-GetConsoleCursorInfo.argtypes = [HANDLE, PCONSOLE_CURSOR_INFO]
-GetConsoleMode.restype = BOOL
-GetConsoleMode.argtypes = [HANDLE, LPDWORD]
-GetConsoleScreenBufferInfo.restype = BOOL
-GetConsoleScreenBufferInfo.argtypes = [HANDLE, PCONSOLE_SCREEN_BUFFER_INFO]
-GetConsoleTitleW.restype = DWORD
-GetConsoleTitleW.argtypes = [LPWSTR, DWORD]
-GetProcAddress.restype = FARPROC
-GetProcAddress.argtypes = [HMODULE, LPCSTR]
-GetStdHandle.restype = HANDLE
-GetStdHandle.argtypes = [DWORD]
-PeekConsoleInputW.restype = BOOL
-PeekConsoleInputW.argtypes = [HANDLE, PINPUT_RECORD, DWORD, LPDWORD]
-ReadConsoleInputW.restype = BOOL
-ReadConsoleInputW.argtypes = [HANDLE, PINPUT_RECORD, DWORD, LPDWORD]
-ScrollConsoleScreenBufferW.restype = BOOL
-ScrollConsoleScreenBufferW.argtypes = [HANDLE, PSMALL_RECT, PSMALL_RECT, COORD, PCHAR_INFO]
-SetConsoleActiveScreenBuffer.restype = BOOL
-SetConsoleActiveScreenBuffer.argtypes = [HANDLE]
-SetConsoleCursorInfo.restype = BOOL
-SetConsoleCursorInfo.argtypes = [HANDLE, PCONSOLE_CURSOR_INFO]
-SetConsoleCursorPosition.restype = BOOL
-SetConsoleCursorPosition.argtypes = [HANDLE, COORD]
-SetConsoleMode.restype = BOOL
-SetConsoleMode.argtypes = [HANDLE, DWORD]
-SetConsoleScreenBufferSize.restype = BOOL
-SetConsoleScreenBufferSize.argtypes = [HANDLE, COORD]
-SetConsoleTextAttribute.restype = BOOL
-SetConsoleTextAttribute.argtypes = [HANDLE, WORD]
-SetConsoleTitleW.restype = BOOL
-SetConsoleTitleW.argtypes = [LPCWSTR]
-SetConsoleWindowInfo.restype = BOOL
-SetConsoleWindowInfo.argtypes = [HANDLE, BOOL, PSMALL_RECT]
-WriteConsoleW.restype = BOOL
-WriteConsoleW.argtypes = [HANDLE, c_void_p, DWORD, LPDWORD, LPVOID]
-WriteConsoleOutputCharacterW.restype = BOOL
-WriteConsoleOutputCharacterW.argtypes = [HANDLE, LPCWSTR, DWORD, COORD, LPDWORD]
-WriteFile.restype = BOOL
-WriteFile.argtypes = [HANDLE, LPCVOID, DWORD, LPDWORD, c_void_p]
+    args = line.split(',')
+    name = args.pop(0)
+    for i in range(len(args)): args[i] = L[args[i]]
+    L[name] = func = getattr(k32, name)
+    func.restype = args.pop(0)
+    func.argtypes = args
+del L, k32, line, args, name, i, func
 
 # I don't want events for these keys, they are just a bother for my application
 key_modifiers = { VK_SHIFT : 1,

--- a/pyreadline/console/console.py
+++ b/pyreadline/console/console.py
@@ -64,16 +64,15 @@ GENERIC_READ = 0x80000000
 GENERIC_WRITE = 0x40000000
 
 # Define Windows data types that we'll need later.  Where possible, use things
-# that are already defined in ctypes or ctypes.wintypes.  Also, use c_void_p
-# for pointer arguments instead of using POINTER() to define a new type so as
-# to be less restrictive.  Using POINTER() clashes with other projects that
-# make use of the kernel32 functions via ctypes since, when used with
-# .argtypes, it forces the new type for the particular argument.  Play nicely!
+# that are already defined in ctypes or ctypes.wintypes.  Also, use a local
+# handle to the kernel32 DLL to avoid problems from setting .restype and
+# .argtypes below that could result from sharing windll.kernel32 with other
+# projects.
 COORD = _COORD
 CHAR = c_char
 FARPROC = c_void_p
-LPDWORD = c_void_p
-PSMALL_RECT = c_void_p
+LPDWORD = POINTER(DWORD)
+PSMALL_RECT = POINTER(SMALL_RECT)
 
 class CONSOLE_SCREEN_BUFFER_INFO(Structure):
     _fields_ = [("dwSize", COORD),
@@ -81,7 +80,7 @@ class CONSOLE_SCREEN_BUFFER_INFO(Structure):
                 ("wAttributes", WORD),
                 ("srWindow", SMALL_RECT),
                 ("dwMaximumWindowSize", COORD)]
-PCONSOLE_SCREEN_BUFFER_INFO = c_void_p
+PCONSOLE_SCREEN_BUFFER_INFO = POINTER(CONSOLE_SCREEN_BUFFER_INFO)
 
 class CHAR_UNION(Union):
     _fields_ = [("UnicodeChar", WCHAR),
@@ -90,7 +89,7 @@ class CHAR_UNION(Union):
 class CHAR_INFO(Structure):
     _fields_ = [("Char", CHAR_UNION),
                 ("Attributes", WORD)]
-PCHAR_INFO = c_void_p
+PCHAR_INFO = POINTER(CHAR_INFO)
 
 class KEY_EVENT_RECORD(Structure):
     _fields_ = [("bKeyDown", BOOL),
@@ -125,15 +124,15 @@ class INPUT_UNION(Union):
 class INPUT_RECORD(Structure):
     _fields_ = [("EventType", WORD),
                 ("Event", INPUT_UNION)]
-PINPUT_RECORD = c_void_p
+PINPUT_RECORD = POINTER(INPUT_RECORD)
 
 class CONSOLE_CURSOR_INFO(Structure):
     _fields_ = [("dwSize", DWORD),
                 ("bVisible", BOOL)]
-PCONSOLE_CURSOR_INFO = c_void_p
+PCONSOLE_CURSOR_INFO = POINTER(CONSOLE_CURSOR_INFO)
 
 L = locals()
-k32 = windll.kernel32
+k32 = WinDLL('kernel32')
 for line in '''
         CreateConsoleScreenBuffer,HANDLE,DWORD,DWORD,c_void_p,DWORD,LPVOID
         FillConsoleOutputAttribute,BOOL,HANDLE,WORD,DWORD,COORD,LPDWORD


### PR DESCRIPTION
Since ctypes caches the kernel32-function look-ups made via ctypes.windll.kernel32 and since the potential exists for the kernel32 functions to be used in other projects, it's better to make use of a local handle to the kernel32 DLL.  This way, any changes made to kernel32 functions via setting .restype and .argtypes are only visible to internal code and not to others.

These changes make pyreadline easier to use in conjunction with other projects and ameliorate issues #18 and #21.  They also make the code easier to maintain by reducing the code used to setup the .restype and .argtypes values.
