### PR TITLE
Make it obvious that pyreadline is for Windows only.

### DIFF
--- a/pyreadline/__init__.py
+++ b/pyreadline/__init__.py
@@ -8,6 +8,12 @@
 #*****************************************************************************
 from __future__ import print_function, unicode_literals, absolute_import
 
+from platform import system
+_S = system()
+if 'windows' != _S.lower():
+    raise RuntimeError('pyreadline is for Windows only, not {}.'.format(_S))
+del system, _S
+
 from . import unicode_helper, logger, clipboard, lineeditor, modes, console
 from .rlmain import *
 from . import rlmain


### PR DESCRIPTION
This change makes it so that pyreadline can only be imported on Windows.
This saves people from wasting time trying to use it on different platforms
only to get weird results or crashes.

This would help alleviate the confusion of issue #13 and others.
