### PR TITLE
Change behavior of return key in the interactive search.

### DIFF
--- a/pyreadline/modes/emacs.py
+++ b/pyreadline/modes/emacs.py
@@ -59,6 +59,8 @@ class IncrementalSearchPromptMode(object):
             self._history.history_cursor = len(self._history.history)
             if keyinfo.keyname == 'escape':
                 self.l_buffer.set_line(self.subsearch_old_line)
+            if keyinfo.keyname == 'return':
+                return False
             return True
         elif keyinfo.keyname:
             pass


### PR DESCRIPTION
Pressing 'return' when the history line is found immediately executes the command
This is often not desirable since the line must to be edited before execution.
