### PR TITLE
Fix Ctrl-R and Ctrl-S prompt that does not accept space character as par...

### DIFF
--- a/pyreadline/modes/emacs.py
+++ b/pyreadline/modes/emacs.py
@@ -60,7 +60,7 @@ class IncrementalSearchPromptMode(object):
             if keyinfo.keyname == 'escape':
                 self.l_buffer.set_line(self.subsearch_old_line)
             return True
-        elif keyinfo.keyname:
+        elif keyinfo.keyname and keyinfo.keyname not in [ 'space' ]:
             pass
         elif keytuple in revtuples:
             self.subsearch_fun = self._history.reverse_search_history


### PR DESCRIPTION
...t of search string.

The space character generates keyinfo events with keyname defined. Such events are
filtered out by IncrementalSearchPromptMode._process_incremental_search_keyevent() if these are
not considered special. While this is true for most characters (unicode and named national characters
to be tested), space is the special case and it is wanted as part of the search string.
