### PR TITLE
Make it run on Python3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 *.bak
 MANIFEST
 *.*~
+*.pyc
+*.pyo

--- a/pyreadline/__init__.py
+++ b/pyreadline/__init__.py
@@ -8,6 +8,7 @@
 #*****************************************************************************
 from __future__ import print_function, unicode_literals, absolute_import
 
-from . import unicode_helper, logger, clipboard, lineeditor, modes, console
-from .rlmain import *
+from . import unicode_helper
+from . import logger, clipboard, lineeditor, modes, console
+from . rlmain import *
 from . import rlmain


### PR DESCRIPTION
This PR contains fixes to allow pyreadline to run on Python 3.5.The PR is based on @zooba's
suggestions and it looks like we won't need any new functions in msvcrt.

It is intended to fix #32 "Use of msvcrt is broken by Python 3.5"

I have done minimal testing in python 2.7-32bit, 3.4-64bit, 3.5-32bit, 3.5-64bit and have seen no issues. 