### PR TITLE
Open history file with utf-8 encoding, fix #55 on Python 3 too

### DIFF
--- a/pyreadline/lineeditor/history.py
+++ b/pyreadline/lineeditor/history.py
@@ -6,7 +6,7 @@
 #  the file COPYING, distributed as part of this software.
 #*****************************************************************************
 from __future__ import print_function, unicode_literals, absolute_import
-import re, operator, string, sys, os
+import re, operator, string, sys, os, io
 
 from pyreadline.unicode_helper import ensure_unicode, ensure_str
 if "pyreadline" in sys.modules:
@@ -79,7 +79,7 @@ class LineHistory(object):
         if filename is None:
             filename = self.history_filename
         try:
-            for line in open(filename, 'r'):
+            for line in io.open(filename, 'r', encoding='utf-8'):
                 self.add_history(lineobj.ReadLineTextBuffer(ensure_unicode(line.rstrip())))
         except IOError:
             self.history = []
@@ -89,7 +89,7 @@ class LineHistory(object):
         '''Save a readline history file.'''
         if filename is None:
             filename = self.history_filename
-        fp = open(filename, 'wb')
+        fp = io.open(filename, 'wb', encoding='utf-8')
         for line in self.history[-self.history_length:]:
             fp.write(ensure_str(line.get_line_text()))
             fp.write('\n'.encode('ascii'))

--- a/pyreadline/lineeditor/history.py
+++ b/pyreadline/lineeditor/history.py
@@ -89,10 +89,10 @@ class LineHistory(object):
         '''Save a readline history file.'''
         if filename is None:
             filename = self.history_filename
-        fp = io.open(filename, 'wb', encoding='utf-8')
+        fp = io.open(filename, 'w', encoding='utf-8')
         for line in self.history[-self.history_length:]:
-            fp.write(ensure_str(line.get_line_text()))
-            fp.write('\n'.encode('ascii'))
+            fp.write(line.get_line_text())
+            fp.write('\n')
         fp.close()
 
 

--- a/pyreadline/lineeditor/history.py
+++ b/pyreadline/lineeditor/history.py
@@ -91,7 +91,7 @@ class LineHistory(object):
             filename = self.history_filename
         fp = io.open(filename, 'w', encoding='utf-8')
         for line in self.history[-self.history_length:]:
-            fp.write(line.get_line_text())
+            fp.write(ensure_unicode(line.get_line_text()))
             fp.write('\n')
         fp.close()
 


### PR DESCRIPTION
A port of @sighingnow's fix for #55 (#57) to work on Python 3.
The reason it doesn't work on Python 3 (specifically Python 3.8.0) is that `'wb'` mode cannot be used in conjunction with the `encoding` argument:
```
Traceback (most recent call last):
  File "C:\Python38\lib\site-packages\pyreadline\rlmain.py", line 169, in write_history_file
    self.mode._history.write_history_file(filename)
  File "C:\Python38\lib\site-packages\pyreadline\lineeditor\history.py", line 92, in write_history_file
    fp = io.open(filename, 'wb', encoding='utf-8')
ValueError: binary mode doesn't take an encoding argument
```

One solution is removing the `encoding` argument, but instead I kept it and changed the mode to `'w'` to be consistent with `read_history_file` that opens the file in mode `'r'`.
In order to make the mode `'w'` work, I replaced the call to `ensure_str` with `ensure_unicode`, and removed the encoding of the newline character.