### PR TITLE
fix: UnicodeDecodeError 'gbk' codec can't decode byte 0x80

### DIFF
--- a/pyreadline/lineeditor/history.py
+++ b/pyreadline/lineeditor/history.py
@@ -79,7 +79,7 @@ class LineHistory(object):
         if filename is None:
             filename = self.history_filename
         try:
-            for line in open(filename, 'r'):
+            for line in open(filename, 'r', encoding='UTF-8'):
                 self.add_history(lineobj.ReadLineTextBuffer(ensure_unicode(line.rstrip())))
         except IOError:
             self.history = []


### PR DESCRIPTION
## I'm submitting a

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring
- [ ] Added tests
- [ ] Documentation
- [ ] Other (`Please describe in detail here`)

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://www.conventionalcommits.org/zh-hans/v1.0.0-beta.4/) pattern
  - A feature commit message is prefixed "feat:"
  - A bug fix commit message is prefixed "fix:"
- [ ] Tests for the changes have been added

## Description

Fix: #62 

1. Before:

```
C:\Users\Francis>python
Python 3.6.5 (v3.6.5:f59c0932b4, Mar 28 2018, 17:00:18) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
Failed calling sys.__interactivehook__
Traceback (most recent call last):
  File "D:\Python\Python36\lib\site.py", line 418, in register_readline
    readline.read_history_file(history)
  File "D:\Python\Python36\lib\site-packages\pyreadline\rlmain.py", line 165, in read_history_file
    self.mode._history.read_history_file(filename)
  File "D:\Python\Python36\lib\site-packages\pyreadline\lineeditor\history.py", line 82, in read_history_file
    for line in open(filename, 'r'):
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 321: illegal multibyte sequence
>>>
```

2. After:

```
C:\Users\Francis>python
Python 3.6.5 (v3.6.5:f59c0932b4, Mar 28 2018, 17:00:18) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>>

```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
