### PR TITLE
BUG: fix regex to avoid DoS

### DIFF
--- a/pyreadline/rlmain.py
+++ b/pyreadline/rlmain.py
@@ -85,7 +85,7 @@ class BaseReadline(object):
                 else:
                     log('bad set "%s"' % string)
                 return
-            m = re.compile(r'\s*(.+)\s*:\s*([-a-zA-Z]+)\s*$').match(string)
+            m = re.compile(r'\s*(\S+)\s*:\s*([-a-zA-Z]+)\s*$').match(string)
             if m:
                 key = m.group(1)
                 func_name = m.group(2)


### PR DESCRIPTION
The regex which can match over long parts of strings but then be rejected by nonmatching at the end can be used for
denial-of-service. This addresses #66