### PR TITLE
Remove deprecation warning

### DIFF
--- a/pyreadline/py3k_compat.py
+++ b/pyreadline/py3k_compat.py
@@ -5,8 +5,8 @@ if sys.version_info[0] >= 3:
     import collections
     PY3 = True
     def callable(x):
-        return isinstance(x, collections.Callable)
-    
+        return isinstance(x, collections.abc.Callable)
+
     def execfile(fname, glob, loc=None):
         loc = loc if (loc is not None) else glob
         with open(fname) as fil:
@@ -22,5 +22,5 @@ else:
     execfile = execfile
     bytes = str
     unicode = unicode
-    
+
     from StringIO import StringIO


### PR DESCRIPTION
I quickly fixed this:

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
```