### PR TITLE
Fix Python 3.10 AtributeError

### DIFF
--- a/pyreadline/py3k_compat.py
+++ b/pyreadline/py3k_compat.py
@@ -5,7 +5,7 @@ if sys.version_info[0] >= 3:
     import collections
     PY3 = True
     def callable(x):
-        return isinstance(x, collections.Callable)
+        return isinstance(x, collections.abc.Callable)
     
     def execfile(fname, glob, loc=None):
         loc = loc if (loc is not None) else glob


### PR DESCRIPTION
Fixed this:
```python
C:\Windows\system32>python
Python 3.10.0 (tags/v3.10.0:b494f59, Oct  4 2021, 19:00:18) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
Failed calling sys.__interactivehook__
Traceback (most recent call last):
  File "C:\Program Files\Python310\lib\site.py", line 446, in register_readline
    import readline
  File "C:\Program Files\Python310\lib\site-packages\readline.py", line 34, in <module>
    rl = Readline()
  File "C:\Program Files\Python310\lib\site-packages\pyreadline\rlmain.py", line 422, in __init__
    BaseReadline.__init__(self)
  File "C:\Program Files\Python310\lib\site-packages\pyreadline\rlmain.py", line 62, in __init__
    mode.init_editing_mode(None)
  File "C:\Program Files\Python310\lib\site-packages\pyreadline\modes\emacs.py", line 633, in init_editing_mode
    self._bind_key('space',       self.self_insert)
  File "C:\Program Files\Python310\lib\site-packages\pyreadline\modes\basemode.py", line 162, in _bind_key
    if not callable(func):
  File "C:\Program Files\Python310\lib\site-packages\pyreadline\py3k_compat.py", line 8, in callable
    return isinstance(x, collections.Callable)
AttributeError: module 'collections' has no attribute 'Callable'
```