### PR TITLE
Fix for variable assignment issue in keysyms mod

### DIFF
--- a/pyreadline/keysyms/__init__.py
+++ b/pyreadline/keysyms/__init__.py
@@ -6,6 +6,8 @@ success = False
 in_ironpython = "IronPython" in sys.version
 from . import winconstants
 
+raised_x = None
+
 if in_ironpython:
     try:
         from .ironpython_keysyms import *
@@ -17,7 +19,7 @@ else:
         from .keysyms import *
         success = True
     except ImportError as x:
-        pass
+        raised_x = x
     
 if not success:
-    raise ImportError("Could not import keysym for local pythonversion", x)
+    raise ImportError("Could not import keysym for local pythonversion", raised_x)


### PR DESCRIPTION
This is a fix for issue #74 which occurs on linux systems.   Alot of things up the stack are depending on the proper ImportError type being raised.

```
Traceback (most recent call last):
  File "../.venv/bin/sphinx-apidoc", line 5, in <module>
    from sphinx.ext.apidoc import main
  File "/media/myron/SSD/source/projects/sonos-qa/automation/.venv/lib/python3.8/site-packages/sphinx/ext/apidoc.py", line 30, in <module>
    from sphinx.cmd.quickstart import EXTENSIONS
  File "/media/myron/SSD/source/projects/sonos-qa/automation/.venv/lib/python3.8/site-packages/sphinx/cmd/quickstart.py", line 22, in <module>
    import readline
  File "/media/myron/SSD/source/projects/sonos-qa/automation/.venv/lib/python3.8/site-packages/readline.py", line 6, in <module>
    from pyreadline.rlmain import Readline
  File "/media/myron/SSD/source/projects/sonos-qa/automation/.venv/lib/python3.8/site-packages/pyreadline/__init__.py", line 12, in <module>
    from . import logger, clipboard, lineeditor, modes, console
  File "/media/myron/SSD/source/projects/sonos-qa/automation/.venv/lib/python3.8/site-packages/pyreadline/clipboard/__init__.py", line 13, in <module>
    from .win32_clipboard import GetClipboardText, SetClipboardText
  File "/media/myron/SSD/source/projects/sonos-qa/automation/.venv/lib/python3.8/site-packages/pyreadline/clipboard/win32_clipboard.py", line 39, in <module>
    from pyreadline.keysyms.winconstants import CF_UNICODETEXT, GHND
  File "/media/myron/SSD/source/projects/sonos-qa/automation/.venv/lib/python3.8/site-packages/pyreadline/keysyms/__init__.py", line 28, in <module>
    raise ImportError("Could not import keysym for local pythonversion", x)
NameError: name 'x' is not defined
```