### PR TITLE
Fix for collections.Callable removal on python >= 3.9

### DIFF
--- a/pyreadline/py3k_compat.py
+++ b/pyreadline/py3k_compat.py
@@ -2,11 +2,14 @@ from __future__ import print_function, unicode_literals, absolute_import
 import sys
 
 if sys.version_info[0] >= 3:
-    import collections
+    try:
+        from collections import Callable
+    except ImportError:
+        from collections.abc import Callable
     PY3 = True
     def callable(x):
-        return isinstance(x, collections.Callable)
-    
+        return isinstance(x, Callable)
+
     def execfile(fname, glob, loc=None):
         loc = loc if (loc is not None) else glob
         with open(fname) as fil:


### PR DESCRIPTION
On **python 3.9** and later (tested with 3.11 alpha-3), `pyreadline`'s startup hook unfortunately fails due to some once-deprecated names being finally removed in the stdlib. The cause is that`Callable` has been removed from the `collections` module since python 3.9  The location to use is `collections.abc`. Slight tweak to the code so that it will work for both setups.

Python Version: Python 3.11.0a3 (main, Dec  8 2021, 22:56:33) [MSC v.1929 64 bit (AMD64)] on win32
PyReadline Version:  pyreadline-2.1 (from pypi ` pyreadline-2.1.zip`)
Full traceback:

```py
Failed calling sys.__interactivehook__
Traceback (most recent call last):
  File "<frozen site>", line 445, in register_readline
  File "C:\Users\David\AppData\Local\Programs\Python\Python311\Lib\site-packages\readline.py", line 34, in <module>
    rl = Readline()
         ^^^^^^^^^^
  File "C:\Users\David\AppData\Local\Programs\Python\Python311\Lib\site-packages\pyreadline\rlmain.py", line 422, in __init__
    BaseReadline.__init__(self)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\David\AppData\Local\Programs\Python\Python311\Lib\site-packages\pyreadline\rlmain.py", line 62, in __init__
    mode.init_editing_mode(None)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\David\AppData\Local\Programs\Python\Python311\Lib\site-packages\pyreadline\modes\emacs.py", line 633, in init_editing_mode
    self._bind_key('space',       self.self_insert)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\David\AppData\Local\Programs\Python\Python311\Lib\site-packages\pyreadline\modes\basemode.py", line 162, in _bind_key
    if not callable(func):
           ^^^^^^^^^^^^^^
  File "C:\Users\David\AppData\Local\Programs\Python\Python311\Lib\site-packages\pyreadline\py3k_compat.py", line 8, in callable
    return isinstance(x, collections.Callable)
                         ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'collections' has no attribute 'Callable'
```