### PR TITLE
Patch for Python 3.10 on Windows

### DIFF
--- a/pyreadline/py3k_compat.py
+++ b/pyreadline/py3k_compat.py
@@ -5,7 +5,7 @@ if sys.version_info[0] >= 3:
     import collections
     PY3 = True
     def callable(x):
-        return isinstance(x, collections.Callable)
+        return isinstance(x, collections.abc.Callable)
     
     def execfile(fname, glob, loc=None):
         loc = loc if (loc is not None) else glob


### PR DESCRIPTION
Patch the error "AttributeError: module 'collections' has no attribute 'Callable'" for the user on Python 3.10 on Windows
If the changes is accept, please update the Pypi package