### PR TITLE
Handling Collections Callable Attribute missing issue in 3.9+

### DIFF
--- a/pyreadline/py3k_compat.py
+++ b/pyreadline/py3k_compat.py
@@ -5,7 +5,7 @@ if sys.version_info[0] >= 3:
     import collections
     PY3 = True
     def callable(x):
-        return isinstance(x, collections.Callable)
+        return isinstance(x, collections.Callable if hasattr(collections, 'Callable') else collections.abc.Callable )
     
     def execfile(fname, glob, loc=None):
         loc = loc if (loc is not None) else glob


### PR DESCRIPTION
In python 3.11, when working on a module, I got below error. 
\pyreadline\py3k_compat.py", line 8, in callable    return isinstance(x, collections.Callable)
                         ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'collections' has no attribute 'Callable'

When researched I understood that Collections module was modified. It moved collections.Callable to collections.abc.Callable Handled that change, bearing in mind backward compatibility