### PR TITLE
3.10 Compatibility Patch

### DIFF
--- a/pyreadline/py3k_compat.py
+++ b/pyreadline/py3k_compat.py
@@ -1,27 +1,32 @@
 from __future__ import print_function, unicode_literals, absolute_import
 import sys
 
-if sys.version_info[0] >= 3:
-    import collections
-    collections.Callable = collections.abc.Callable
-    PY3 = True
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+PY3 = sys.version_info[0] >= 3
+
+if PY3:
+    try:
+        from collections.abc import Callable
+    except ImportError:
+        from collections import Callable
+
     def callable(x):
-        return isinstance(x, collections.Callable)
+        return isinstance(x, Callable)
     
     def execfile(fname, glob, loc=None):
-        loc = loc if (loc is not None) else glob
+        loc = glob if loc is None else loc
         with open(fname) as fil:
             txt = fil.read()
         exec(compile(txt, fname, 'exec'), glob, loc)
-
+    
     unicode = str
     bytes = bytes
-    from io import StringIO
 else:
-    PY3 = False
     callable = callable
     execfile = execfile
     bytes = str
     unicode = unicode
-    
-    from StringIO import StringIO

--- a/pyreadline/py3k_compat.py
+++ b/pyreadline/py3k_compat.py
@@ -3,6 +3,7 @@ import sys
 
 if sys.version_info[0] >= 3:
     import collections
+    collections.Callable = collections.abc.Callable
     PY3 = True
     def callable(x):
         return isinstance(x, collections.Callable)


### PR DESCRIPTION
## Summary

Made a small adjustment to `py3k_compat` to allow `pyreadline` to be imported without issue on Python versions 3.10 or greater.

### Details

- Thorough testing to ensure correct functionality for Python 3.10+ while maintaining back-compatibility.
- Applied necessary modifications to maintain backward compatibility with older Python versions.

### Issues Fixed

- Fixes #65 
- Fixes #73 
- Closes #68 
- Closes #72
- Closes #78
- Closes #80 
- Closes #81 
- Closes #82 

### Testing
[![Python package](https://github.com/DJStompZone/pyreadline/actions/workflows/python-tests.yml/badge.svg?branch=test-workflow-1&refresh=true)](https://github.com/DJStompZone/pyreadline/actions/workflows/python-tests.yml)
- Tested on Python 3.6 - 3.13 to verify import functionality.
- Confirmed that the changes do not affect older Python versions.